### PR TITLE
Added support for data attributes

### DIFF
--- a/stylist.js
+++ b/stylist.js
@@ -15,12 +15,13 @@ stylist.extract = function ( content, options ){
     // other than that, selectors are defined the same way
     , braces = style == "styl" || style == "stylus" ? "" : "{}"
     , validSelector = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
+    , regxp = /class\s*=\s*"([^"]+)"|\sid\s*=\s*"([^"]+)"|data-([A-z]+)\s*=\s*"([^"]+)"/g    
 
   function isDefinedElsewhere( selector ){
     return new RegExp(selector+"\\s*" + (braces ? "{" : "(\\n|{)?")).test(ignore)
   }
 
-  content.replace(/class\s*=\s*"([^"]+)"|id\s*=\s*"([^"]+)"/g, function ( match, cls, id ){
+  content.replace(regxp, function ( match, cls, id, data, data_value ){
     if ( cls ) {
       cls.trim().split(/\s+/).forEach(function ( cls ){
         if( !validSelector.test(cls) ) return
@@ -37,7 +38,14 @@ stylist.extract = function ( content, options ){
       id += braces
       if( !!~selectors.indexOf(id) ) return match
       selectors.push(id)
-    }
+    } 
+    else if ( data ) {      
+      if( !validSelector.test ) return
+      if( isDefinedElsewhere("\\[data-"+data+"\\=" + data_value + "\\]") ) return match
+      data = "[data-" + data + "=" + data_value + "]" + braces
+      if( !!~selectors.indexOf(data) ) return
+      selectors.push(data)
+    }     
     return match
   })
 

--- a/test/collection/hey.html
+++ b/test/collection/hey.html
@@ -10,5 +10,6 @@
   <div class="ho"></div>
   <div class="ho"></div>
   <div class="lets go"></div>
+  <div data-hey="ho" data-foo="foo"></div>
 </body>
 </html>

--- a/test/collection/ho.html
+++ b/test/collection/ho.html
@@ -8,5 +8,6 @@
   <div id="hey"></div>
   <div class="ho"></div>
   <div class="lets go"></div>
+	<div data-man="super"></div>  
 </body>
 </html>


### PR DESCRIPTION
I though it would be a great idea to add support for HTML5 data attributes:
https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes

Example: `<div data-foo="foo">`
